### PR TITLE
Fix browser bug with undefined SharedKeyCredential

### DIFF
--- a/src/persistence/azureBlobStorage.ts
+++ b/src/persistence/azureBlobStorage.ts
@@ -138,7 +138,7 @@ export class AzureBlobStorage implements IBlobStorage {
         const containerUrl = await this.initialize();
 
         try {
-            if (this.credential instanceof SharedKeyCredential) {
+            if (SharedKeyCredential && this.credential instanceof SharedKeyCredential) {
                 const now = new Date();
                 now.setMinutes(now.getMinutes() - 5); // Skip clock skew with server
 


### PR DESCRIPTION
The fix for getDownloadUrl (9970dfe6593accd0a9b38f0dcdacdb8d3f3b5661) doesn't seem to work if the code runs in the browser (e.g. when running the designer tool) because SharedKeyCredential is only available in Node.js.

This just checks SharedKeyCredential exists before doing the instanceof check, otherwise you get a `TypeError: Right-hand side of 'instanceof' is not an object`