### PR TITLE
Upgrade dependencies of azure/storage-blob and mocha packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "url": "https://github.com/paperbits/paperbits-azure/issues"
     },
     "dependencies": {
-        "@azure/storage-blob": "12.5.0",
+        "@azure/storage-blob": "12.14.0",
         "@paperbits/common": "0.1.580",
         "applicationinsights-js": "1.0.21",
         "mime": "3.0.0"
@@ -24,9 +24,9 @@
     "devDependencies": {
         "@types/applicationinsights-js": "^1.0.9",
         "@types/chai": "^4.2.16",
-        "@types/mocha": "^8.2.2",
+        "@types/mocha": "^10.0.1",
         "chai": "^4.3.4",
-        "mocha": "^8.3.2",
+        "mocha": "^10.2.0",
         "ts-node": "^9.1.1",
         "typescript": "4.2.4"
     }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/104755925/234295342-06db845a-0f18-4b60-adf5-9720e4006e64.png)
There 7 vulnerabilities coming from azure/storage-blob and mocha packages.
Upgrade to solve the npm audit warnings. 